### PR TITLE
CLI.banner: multiline + expandable box

### DIFF
--- a/lib/bottle/cli.ex
+++ b/lib/bottle/cli.ex
@@ -13,10 +13,23 @@ defmodule Bottle.CLI do
 
   @spec banner(String.t()) :: :ok
   def banner(msg) do
+    {lines, max_line_len} =
+      msg
+      |> String.split(~r/[\r\n]+/)
+      |> Enum.reduce({[], 40}, fn s, {lines, max_line_len} ->
+        {[s | lines], max(max_line_len, String.length(s))}
+      end)
+
+    lines_str =
+      lines
+      |> Enum.reverse()
+      |> Enum.map(&"\n** #{String.pad_trailing(&1, max_line_len)} **")
+      |> Enum.join()
+
     "\n#{IO.ANSI.green()}" <>
-    String.duplicate("*", 40) <>
-    "\n** #{String.pad_trailing(msg, 34)} **\n" <>
-    String.duplicate("*", 40) <>
+    String.duplicate("*", max_line_len+6) <>
+    lines_str <> "\n" <>
+    String.duplicate("*", max_line_len+6) <>
     "\n#{IO.ANSI.reset()}"
     |> IO.puts()
   end


### PR DESCRIPTION
Correctly display multiline strings and allow the box to grow to adapt to large lines:

```
bottle(6)> CLI.banner "This is a pretty big line which overflows the previous limits and makes the box grow\n\nAnd also, multiline"

******************************************************************************************
** This is a pretty big line which overflows the previous limits and makes the box grow **
** And also, multiline                                                                  **
******************************************************************************************

:ok
```